### PR TITLE
Make regex compatible with Rust style for `bat` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Fork of [Terraform.tmLanguage][base_repo] with some sweet improvements.
 * Syntax highlighting for `.tf` and `.tfvars` files.
 * Format on save using `terraform fmt` (only available in version >= 0.6.15)
 * Code completion for resources and data sources
+* Support [`bat`](https://github.com/sharkdp/bat)
 * Snippets
 
 Installation

--- a/Terraform.sublime-syntax
+++ b/Terraform.sublime-syntax
@@ -78,7 +78,7 @@ contexts:
         2: string.terraform punctuation.definition.string.begin.terraform
         3: string.quoted.double.terraform
         4: string.terraform punctuation.definition.string.end.terraform
-    - match: '(output)\s+(")([\w-\.]+)(")\s*{'
+    - match: '(output)\s+(")([-\w\.]+)(")\s*{'
       scope: entity.name.resource.terraform
       captures:
         1: storage.type.function.terraform


### PR DESCRIPTION
These changes should be universally compatible.

Solves the dreaded `unmatched range specifier in char-class` error.

Thanks @nilium!!!